### PR TITLE
Fix OSError when running server from same directory as the server itself

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -16,7 +16,9 @@ from ConfigParser import ConfigParser
 
 #### CONFIGURATION AND PRE-PROCESSING
 # The script has to run from the location on disk that it lives.
-os.chdir(os.path.dirname(__file__))
+dirname = os.path.dirname(__file__)
+if dirname:
+    os.chdir(os.path.dirname(__file__))
 
 # Next we need to load the configuration file into memory.
 config = ConfigParser()


### PR DESCRIPTION
When I run app.py, I get this error:

```
chris@home:~/dev/bukget/server$ python app.py
Traceback (most recent call last):
  File "app.py", line 19, in <module>
    os.chdir(os.path.dirname(__file__))
OSError: [Errno 2] No such file or directory: ''
```

This is because when the server is run this way, `__file__ == 'app.py'`, therefore `os.path.dirname(__file__)` is an empty string.

This commit fixes this error by checking for an empty string before calling `os.chdir()`.
