### PR TITLE
Add Hash/Filename Tracking

### DIFF
--- a/server.js
+++ b/server.js
@@ -409,6 +409,12 @@ module.exports = function (database, callback) {
               'latest': {'version': versions[0]['version'], 'download': versions[0]['download'], 'md5': versions[0]['md5'] }
             },
           }
+          if (hash_list && hash_list[i]) {
+            entry.hash = hash_list[i];
+          }
+          if (file_list && file_list[i]) {
+            entry.file = file_list[i];
+          }
 
           for (var x = 0, versionLen = versions.length; x < versionLen; x++) {
             version = versions[x];
@@ -417,6 +423,9 @@ module.exports = function (database, callback) {
               if (entry['versions'][version['type'].toLowerCase()] == null) {
                 entry['versions'][version['type'].toLowerCase()] = { 'version': version['version'], 'download': version['download'], 'md5': version['md5'] };
               }
+            }
+            if (hash_list && hash_list[i] && hash_list[i] == version['md5']) {
+              entry['versions']['search'] = { 'version': version['version'], 'download': version['download'], 'md5': version['md5'] };
             }
           }
 


### PR DESCRIPTION
This will allow a requesting script to track a hash or filename that was searched, with an internal list. This way the requesting script can track multiple files on local disk to replace and update with a single request.

This change will also report the given version of the requested hash, if given. This allows the requester to know that version X.XX needs to be upgraded to version Y.YY.
