### PR TITLE
Add Current Result to /update

### DIFF
--- a/server.js
+++ b/server.js
@@ -409,6 +409,12 @@ module.exports = function (database, callback) {
               'latest': {'version': versions[0]['version'], 'download': versions[0]['download'], 'md5': versions[0]['md5'] }
             },
           }
+          if (hash_list && hash_list[i]) {
+            entry.hash = hash_list[i];
+          }
+          if (file_list && file_list[i]) {
+            entry.file = file_list[i];
+          }
 
           for (var x = 0, versionLen = versions.length; x < versionLen; x++) {
             version = versions[x];
@@ -417,6 +423,9 @@ module.exports = function (database, callback) {
               if (entry['versions'][version['type'].toLowerCase()] == null) {
                 entry['versions'][version['type'].toLowerCase()] = { 'version': version['version'], 'download': version['download'], 'md5': version['md5'] };
               }
+            }
+            if (hash_list && hash_list[i] && hash_list[i] == version['md5']) {
+              entry['versions']['current'] = { 'version': version['version'], 'download': version['download'], 'md5': version['md5'] };
             }
           }
 

--- a/test/test.js
+++ b/test/test.js
@@ -497,7 +497,7 @@ describe('Categories', function() {
 });
 
 describe('Updates', function() {
-  var update_versions = { 'latest': { 'version': plugin_two.versions[0]['version'], 'download': 'http://dev.bukkit.org/media/files/599/604/AbitOfRealism.jar', 'md5': '236c18df1d15e149fe91675c08efa8b5' } };
+  var update_versions = { 'current': {"version":"0.3","download":"http://dev.bukkit.org/media/files/597/975/AbitOfRealism.jar","md5":"49ab15446ae1bfce8801433cd75f8fc9"}, 'latest': { 'version': plugin_two.versions[0]['version'], 'download': 'http://dev.bukkit.org/media/files/599/604/AbitOfRealism.jar', 'md5': '236c18df1d15e149fe91675c08efa8b5' }};
   before(function (done) {
     db.plugins.insert(plugin_two, {safe: true}, function (err, records) {
       var versions = plugin_two.versions;
@@ -513,6 +513,20 @@ describe('Updates', function() {
       done();
     });
   });
+  it('returns list of latest versions by md5', function (done) {
+    request(instance)
+      .get('/3/updates?hashes=49ab15446ae1bfce8801433cd75f8fc9')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end(function (err,res) {
+        if (err) {
+          throw err;
+        }
+        (res.res.body).should.eql([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions, 'hash': '49ab15446ae1bfce8801433cd75f8fc9' }]);
+        done();
+      });
+  });
   it('returns list of latest versions via get', function (done) {
     request(instance)
       .get('/3/updates?slugs=abitofrealism')
@@ -523,7 +537,8 @@ describe('Updates', function() {
         if (err) {
           throw err;
         }
-        JSON.stringify(res.res.body).should.equal(JSON.stringify([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions }]));
+        if (update_versions.current) delete update_versions.current;
+        (res.res.body).should.eql([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions }]);
         done();
       });
   });
@@ -537,7 +552,8 @@ describe('Updates', function() {
         if (err) {
           throw err;
         }
-        JSON.stringify(res.res.body).should.equal(JSON.stringify([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions }]));
+        if (update_versions.current) delete update_versions.current;
+        (res.res.body).should.eql([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions }]);
         done();
       });
   });
@@ -551,22 +567,8 @@ describe('Updates', function() {
         if (err) {
           throw err;
         }
-        JSON.stringify(res.res.body).should.equal(JSON.stringify([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions }]));
-        done();
-      });
-  });
-  it('returns list of latest versions by md5', function (done) {
-    request(instance)
-      .get('/3/updates?hashes=49ab15446ae1bfce8801433cd75f8fc9')
-      .set('Accept', 'application/json')
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .end(function (err,res) {
-        if (err) {
-          throw err;
-        }
-        update_versions.search = {"version":"0.3","download":"http://dev.bukkit.org/media/files/597/975/AbitOfRealism.jar","md5":"49ab15446ae1bfce8801433cd75f8fc9"};
-        JSON.stringify(res.res.body).should.equal(JSON.stringify([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions, 'hash': '49ab15446ae1bfce8801433cd75f8fc9' }]));
+        if (update_versions.current) delete update_versions.current;
+        (res.res.body).should.eql([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions }]);
         done();
       });
   });
@@ -580,7 +582,8 @@ describe('Updates', function() {
         if (err) {
           throw err;
         }
-        JSON.stringify(res.res.body).should.equal(JSON.stringify([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions }, 'file': 'AbitOfRealism.jar']));
+        if (update_versions.current) delete update_versions.current;
+        (res.res.body).should.eql([{ "slug": plugin_two.slug, "plugin_name": plugin_two.plugin_name, "versions": update_versions, 'file': 'AbitOfRealism.jar' }]);
         done();
       });
   });


### PR DESCRIPTION
This will allow a requesting script to track a hash or filename that was searched, with an internal list. This way the requesting script can track multiple files on local disk to replace and update with a single request.

This change will also report the given version of the requested hash, if given. This allows the requester to know that version X.XX needs to be upgraded to version Y.YY.

The changes to the test file use should.eql for a deeper object comparison, which may be slower but will be more reliable in this test.
